### PR TITLE
Syntax coloring not working on closing tags

### DIFF
--- a/Syntaxes/JavaDoc.tmLanguage
+++ b/Syntaxes/JavaDoc.tmLanguage
@@ -411,7 +411,7 @@
 								a tag that will not end. List of allowed tags taken from
 								java checkstyle.</string>
 					<key>match</key>
-					<string>&lt;(?!(a|abbr|acronym|address|area|b|bdo|big|blockquote|br|caption|cite|code|colgroup|dd|del|div|dfn|dl|dt|em|fieldset|font|h1toh6|hr|i|img|ins|kbd|li|ol|p|pre|q|samp|small|span|strong|sub|sup|table|tbody|td|tfoot|th|thread|tr|tt|u|ul)\b[^&gt;]*&gt;)</string>
+					<string>&lt;(?!/?(a|abbr|acronym|address|area|b|bdo|big|blockquote|br|caption|cite|code|colgroup|dd|del|div|dfn|dl|dt|em|fieldset|font|h1toh6|hr|i|img|ins|kbd|li|ol|p|pre|q|samp|small|span|strong|sub|sup|table|tbody|td|tfoot|th|thread|tr|tt|u|ul)\b[^&gt;]*&gt;)</string>
 				</dict>
 				<dict>
 					<key>include</key>


### PR DESCRIPTION
Steps to Reproduce:

1. Create a java file with some Javadoc and some html tags in it.
2. Only the opening html tags are colored properly, not the closing ones (see `</p>` below)

<img width="358" alt="capture d ecran 2016-11-24 a 16 30 07" src="https://cloud.githubusercontent.com/assets/148698/20610173/fb12c95c-b263-11e6-9080-a40baff63dca.png">

```java
/**
 * <p>Note:</p> Hello
 */
public class TestClass {
}
```